### PR TITLE
Google webscraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,26 +25,17 @@ Installation
   <plugin name="translator" config="@b3/extplugins/translator/conf/plugin_translator.ini" />
   ```
 
-Microsoft Translator API configuration
---------------------------------------
-
-1. Create a new [Windows Live ID](https://signup.live.com)
-2. Create an account on the [Azure Data Market](https://datamarket.azure.com/developer/applications/)
-3. Pick a service [plan](https://datamarket.azure.com/dataset/1899a118-d202-492c-aa16-ba21c33c06cb)
-4. Register an Azure [application](https://datamarket.azure.com/developer/applications)
-5. While registering the new application you will need to specify a **website** and a **software name**: you can use
-as website **http://localhost** and as software name whatever name you like more
-
-The Azure Application registration, provides two critical fields for **API** access: **client id** and **client secret**:
-you have to put those credentials inside the plugin configuration file.
+* install langdetect python module (from pypi) to support exclude_language setting.
 
 In-game user guide
 ------------------
 
 * **!translate [&lt;source&gt;]*[&lt;target&gt;] &lt;message&gt;** `translate a message`
 * **!translast [&lt;target&gt;]** `translate the last available sentence from the chat`
-* **!transauto &lt;on|off&gt;** `turn on/off the automatic translation`
+* **!transauto &lt;on|off&gt;** `turn on/off the automatic translation` - STRONGLY DISADVISED (unless you would like your server to get banned from Google...)
 * **!translang** `display the list of available language codes`
+
+It is advised to increase min_time_between to reduce the likelihood of a google temporary ban.
 
 Support
 -------

--- a/extplugins/translator/__init__.py
+++ b/extplugins/translator/__init__.py
@@ -33,7 +33,7 @@
 # 2017/06/02 - 3.2 - GrosBedo - add exclude_language setting to skip messages in a given language from !translast
 
 __author__ = 'GrosBedo'
-__version__ = '3.1'
+__version__ = '3.2'
 
 import b3
 import b3.plugin
@@ -517,7 +517,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
         # exclude last messages with language we know well
         excl_lang = self.settings['exclude_language']
         if excl_lang:
-            for msg in last_message_said[::-1]:
+            for msg in self.last_message_said[::-1]:
                 # keep this message as the one to translate
                 last_msg = msg
                 # Detect language: if not an excluded language, we break and keep this message
@@ -528,10 +528,10 @@ class TranslatorPlugin(b3.plugin.Plugin):
                     break
         else:
             # else, just pick the last message in the list
-            last_msg = last_message_said[-1]
+            last_msg = self.last_message_said[-1]
 
         # translate
-        message = self.translate(self.last_msg, to_lang=tar)
+        message = self.translate(last_msg, to_lang=tar)
         if not message:
             client.message('^7unable to translate')
             return

--- a/extplugins/translator/__init__.py
+++ b/extplugins/translator/__init__.py
@@ -27,21 +27,40 @@
 #                          - general improvements
 #                          - added automated tests
 # 2015/02/07 - 2.8 - Fenix - new plugin module structure
+# 2017/05/31 - 3.0 - GrosBedo & Lotabout - new interface to google via web scraping
+#                                                                  - add min_time_between to limit number of requests
 
-__author__ = 'Fenix'
-__version__ = '2.8'
+__author__ = 'GrosBedo'
+__version__ = '3.0'
 
 import b3
 import b3.plugin
 import b3.events
+
+# translate utility that utilize google translator, support python2 & python3
+# Note that the order or arguments in the URL matters.
+
+try:
+    from urllib import urlencode
+except:
+    from urllib.parse import urlencode
+
+try:
+    import urllib2
+except:
+    import urllib.request as urllib2
+
 import json
 import re
+import sys
+import time
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 from ConfigParser import NoOptionError
-from urllib import urlencode
-from urllib2 import urlopen
-from urllib2 import Request
-from urllib2 import URLError
+#from urllib2 import urlopen
+#from urllib2 import Request
+#from urllib2 import URLError
 
 try:
     # import the getCmd function
@@ -61,6 +80,8 @@ class TranslatorPlugin(b3.plugin.Plugin):
     adminPlugin = None
     cmdPrefix = None
 
+    lastTime = None
+
     # configuration values
     settings = {
         'default_source_language': 'auto',
@@ -68,8 +89,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
         'display_translator_name': True,
         'translator_name': '^7[^1T^7]',
         'min_sentence_length': 6,
-        'microsoft_client_id': None,
-        'microsoft_client_secret': None
+        'min_time_between': 30,
     }
 
     last_message_said = ''
@@ -80,7 +100,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
         'fi': 'Finnish', 'fr': 'French', 'de': 'German', 'el': 'Greek', 'ht': 'Haitian Creole', 'he': 'Hebrew',
         'hi': 'Hindi', 'hu': 'Hungarian', 'id': 'Indonesian', 'it': 'Italian', 'lv': 'Latvian', 'lt': 'Lithuanian',
         'no': 'Norwegian', 'pl': 'Polish', 'pt': 'Portuguese', 'ro': 'Romanian', 'sl': 'Slovenian', 'es': 'Spanish',
-        'sv': 'Swedish', 'th': 'Thai', 'tr': 'Turkish', 'uk': 'Ukrainian'
+        'sv': 'Swedish', 'th': 'Thai', 'tr': 'Turkish', 'uk': 'Ukrainian', 'ru': 'Russian', 'zh': 'Chinese',
     }
 
     def onLoadConfig(self):
@@ -141,28 +161,15 @@ class TranslatorPlugin(b3.plugin.Plugin):
                        self.settings['min_sentence_length'])
 
         try:
-            value = self.config.get('settings', 'microsoft_client_id')
-            if value and len(value.strip()) != 0:
-                self.settings['microsoft_client_id'] = value
-                self.debug('loaded microsoft_client_id setting: %s' % self.settings['microsoft_client_id'])
-            else:
-                self.warning('invalid value speficied in settings/microsoft_client_id: plugin will be disabled')
+            self.settings['min_time_between'] = self.config.getint('settings', 'min_time_between')
+            self.debug('loaded min_time_between setting: %s' % self.settings['min_time_between'])
         except NoOptionError:
-            self.warning('could not find settings/microsoft_client_id in config file: plugin will be disabled')
-
-        try:
-            value = self.config.get('settings', 'microsoft_client_secret')
-            if value and len(value.strip()) != 0:
-                self.settings['microsoft_client_secret'] = value
-                self.debug('loaded microsoft_client_secret setting: %s' % self.settings['microsoft_client_secret'])
-            else:
-                self.warning('invalid value speficied in settings/microsoft_client_secret: plugin will be disabled')
-        except NoOptionError:
-            self.warning('could not find settings/microsoft_client_secret in config file: plugin will be disabled')
-
-        if not self.settings['microsoft_client_id'] or not self.settings['microsoft_client_secret']:
-            self.error('microsoft translator is not configured properly: disabling the plugin...')
-            self.disable()
+            self.warning('could not find settings/min_time_between in config file, '
+                         'using default: %s' % self.settings['min_time_between'])
+        except ValueError, e:
+            self.error('could not load settings/min_time_between config value: %s' % e)
+            self.debug('using default value (%s) for settings/min_time_between' %
+                       self.settings['min_time_between'])
 
     def onStartup(self):
         """
@@ -216,6 +223,77 @@ class TranslatorPlugin(b3.plugin.Plugin):
     ##                                                                                                                ##
     ####################################################################################################################
 
+    def format_json(self, result, max_entries=5):
+        if max_entries is None:
+            max_entries = 999999
+
+        ret = []
+        for sentence in result['sentences']:
+            ret.append(sentence['orig'] + ': ' + sentence['trans'])
+            ret.append('')
+
+        # format pos
+        if 'dict' in result:
+            for pos in result['dict']:
+                ret.append(pos['pos'])
+                for entry in pos['entry'][:max_entries]:
+                    ret.append(entry['word'] + ': ' + ', '.join(entry['reverse_translation']))
+                ret.append('')
+
+        return '\n'.join(ret)
+
+    def translate(self, text, from_lang="auto", to_lang="en-EN"):
+        """translate text, return the result as json"""
+        self.debug('attempting to translate message -> %s : %s' % (to_lang, text))
+
+        url = 'https://translate.googleapis.com/translate_a/single?'
+
+        params = []
+        params.append('client=gtx')
+        params.append('sl=' + from_lang)
+        params.append('tl=' + to_lang)
+        params.append('hl=en-US')
+        params.append('dt=t')
+        params.append('dt=bd')
+        params.append('dj=1')
+        params.append('source=input')
+        params.append(urlencode({'q': text}))
+        url += '&'.join(params)
+
+        request = urllib2.Request(url)
+        browser = "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
+        request.add_header('User-Agent', browser)
+        response = urllib2.urlopen(request)
+        rtn = json.loads(response.read().decode('utf8'))
+        self.verbose('translation done and received, sanitizing...')
+
+        # formatting the string
+        msg = self.format_json(rtn)
+        msg = self.str_sanitize(msg)
+        if not msg:
+            self.debug('could not translate message (%s): empty string returned' % text)
+            return None
+
+        # print as verbose not to spam too many log lines in debug configuration
+        self.verbose('message translated [ source <%s> : %s | result <%s> : %s ]' % (from_lang, text, to_lang, msg))
+        return msg
+
+    def voice(self, text, lang='en'):
+        """return the sound of an word, in mp3 bytes"""
+        url = 'https://translate.googleapis.com/translate_tts?'
+
+        params = []
+        params.append('client=gtx')
+        params.append('ie=UTF-8')
+        params.append('tl=' + lang)
+        params.append(urlencode({'q': text}))
+        url += '&'.join(params)
+        request = urllib2.Request(url)
+        browser = "Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0"
+        request.add_header('User-Agent', browser)
+        response = urllib2.urlopen(request)
+        return response.read()
+
     def onEvent(self, event):
         """
         Old event dispatch system
@@ -223,15 +301,6 @@ class TranslatorPlugin(b3.plugin.Plugin):
         if event.type == self.console.getEventID('EVT_CLIENT_SAY') or \
             event.type == self.console.getEventID('EVT_CLIENT_TEAM_SAY'):
             self.onSay(event)
-
-    def onEnable(self):
-        """
-        Executed when the plugin is enabled
-        """
-        if not self.settings['microsoft_client_id'] or not self.settings['microsoft_client_secret']:
-            self.warning('could not enable plugin translator: microsoft translator is not configured properly')
-            self.console.say('Plugin ^3Translator ^7is now ^1OFF')
-            self.disable()
 
     def onSay(self, event):
         """
@@ -243,6 +312,14 @@ class TranslatorPlugin(b3.plugin.Plugin):
         # if not enough length
         if len(message) < self.settings['min_sentence_length']:
             return
+
+        # check if we are not spamming requests
+        curTime = time.time()
+        if self.lastTime and curTime - self.lastTime <= self.settings['min_time_between']:
+            return
+        else:
+            # update last time with current time
+            self.lastTime = curTime
 
         # if it's not a B3 command
         if message[0] not in self.cmdPrefix:
@@ -261,7 +338,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
                 # no one has transauto enabled
                 return
 
-            translation = self.translate('', self.settings['default_target_language'], message)
+            translation = self.translate(message, to_lang=self.settings['default_target_language'])
             if not translation:
                 # we didn't managed to get a valid translation
                 # no need to spam the chat of everyone with a silly message
@@ -302,73 +379,6 @@ class TranslatorPlugin(b3.plugin.Plugin):
     ##   TRANSLATION METHODS                                                                                          ##
     ##                                                                                                                ##
     ####################################################################################################################
-
-    def get_access_token(self, client_id, client_secret):
-        """
-        Make an HTTP POST request to the token service, and return the access_token
-        See description here: http://msdn.microsoft.com/en-us/library/hh454949.aspx
-        """
-        data = urlencode({'client_id': client_id,
-                          'client_secret': client_secret,
-                          'grant_type': 'client_credentials',
-                          'scope': 'http://api.microsofttranslator.com'})
-    
-        try:
-            self.debug('requesting microsoft translator access token.....')
-            req = Request('https://datamarket.accesscontrol.windows.net/v2/OAuth2-13')
-            req.add_data(data)
-            res = urlopen(req)
-            rtn = json.loads(res.read())
-            if 'access_token' in rtn.keys():
-                return rtn['access_token']
-
-        except (URLError, TypeError), e:
-            # just print error in log and let the method return false
-            # this was split into several exceptions catches but it makes no
-            # sense since without the access token we are not able to translate
-            self.error('could not request microsoft translator access token: %s' % e)
-
-        return False
-
-    def translate(self, source, target, message):
-        """
-        Translate the given sentence in the specified target language
-        """
-        try:
-
-            self.debug('attempting to translate message -> %s : %s' % (target, message))
-            token = self.get_access_token(self.settings['microsoft_client_id'],
-                                          self.settings['microsoft_client_secret'])
-        
-            if not token:
-                # we got no token so we cannot perform the translation
-                return None
-            
-            data = {'text': self.to_byte_string(message), 'to': target}
-            
-            if source != 'auto' and source != '':
-                # if we got a valid source language
-                data['from'] = source
-
-            # getting the translation
-            req = Request('http://api.microsofttranslator.com/v2/Http.svc/Translate?' + urlencode(data))
-            req.add_header('Authorization', 'Bearer ' + token)
-            res = urlopen(req)
-            rtn = res.read()
-            
-            # formatting the string
-            msg = self.str_sanitize(rtn)
-            if not msg:
-                self.debug('could not translate message (%s): empty string returned' % message)
-                return None
-
-            # print as verbose not to spam too many log lines in debug configuration
-            self.verbose('message translated [ source <%s> : %s | result <%s> : %s ]' % (source, message, target, msg))
-            return msg
-
-        except (URLError, TypeError), e:
-            self.error('could not translate message (%s): %s' % e)
-            return None
 
     def send_translation(self, client, message, cmd=None):
         """
@@ -432,7 +442,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
             # get the real message to be translated
             data = m.group('message')
 
-        translation = self.translate(src, tar, data)
+        translation = self.translate(data, src, tar)
         if not translation:
             client.message('^7unable to translate')
             return
@@ -460,7 +470,7 @@ class TranslatorPlugin(b3.plugin.Plugin):
             # use the provided language code
             tar = data
 
-        message = self.translate('', tar, self.last_message_said)
+        message = self.translate(self.last_message_said, to_lang=tar)
         if not message:
             client.message('^7unable to translate')
             return

--- a/extplugins/translator/conf/plugin_translator.ini
+++ b/extplugins/translator/conf/plugin_translator.ini
@@ -24,6 +24,8 @@ min_sentence_length: 6
 min_time_between: 30
 # always say loudly any translated message? [default = on]
 always_loud: on
+# language to exclude of !translast, which means that messages in history in this language will be skipped (leave empty if you don't want to exclude) [default = en]
+exclude_language: en
 
 [commands]
 translate: reg

--- a/extplugins/translator/conf/plugin_translator.ini
+++ b/extplugins/translator/conf/plugin_translator.ini
@@ -20,10 +20,8 @@ display_translator_name: yes
 translator_name: ^7[^1T^7]
 # minimum length of a message to be translated using !transauto and !translast [default = 6]
 min_sentence_length: 6
-# microsoft translator client id [FILL THIS OR THE PLUGIN WON'T WORK]
-microsoft_client_id:
-# microsoft translator client secret [FILL THIS OR THE PLUGIN WON'T WORK]
-microsoft_client_secret:
+# minimum time to wait before two translations, to avoid google blacklist, in seconds [default = 30]
+min_time_between: 30
 
 [commands]
 translate: reg

--- a/extplugins/translator/conf/plugin_translator.ini
+++ b/extplugins/translator/conf/plugin_translator.ini
@@ -22,6 +22,8 @@ translator_name: ^7[^1T^7]
 min_sentence_length: 6
 # minimum time to wait before two translations, to avoid google blacklist, in seconds [default = 30]
 min_time_between: 30
+# always say loudly any translated message? [default = on]
+always_loud: on
 
 [commands]
 translate: reg


### PR DESCRIPTION
This PR restores the functionalities of this plugin by using Google via webscraping (no API access, so it's free).

Some enhancements are provided, such as ignoring past messages in english (or a defined language) when using !translast (so you only translate non-english sentences).

Also, a minimum delay between translations requests has been implemented, default is 30 seconds, but I would advise to increase this value, to reduce the likelihood of getting temporarily banned by Google.